### PR TITLE
Shifting sunvectors by timezone

### DIFF
--- a/GHSolar/GHSkydome.cs
+++ b/GHSolar/GHSkydome.cs
@@ -314,50 +314,7 @@ namespace GHSolar
             SunVector.Create8760SunVectors(out sunvectors_list, longitude, latitude, year);
             
             //shifting list of sunvectors according to timezone, so it matches weather file data
-            if (timezone != 0)
-            {
-                int horizon = sunvectors_list.Count;
-                List<SunVector> copy_array = new List<SunVector>();
-                int [] shifted_indices = new int[horizon];
-                for (int i = 0; i < horizon; i++)
-                    shifted_indices[i] = i;
-                if (timezone < 0)
-                {
-                    int _count = 0;
-                    for (int i = Math.Abs(timezone); i < horizon; i++)
-                    {
-                        shifted_indices[_count] = i;
-                        _count++;
-                    }
-
-                    for (int i = 0; i < Math.Abs(timezone); i++)
-                    {
-                        shifted_indices[_count] = i;
-                        _count++;
-                    }
-                }
-                else
-                {
-                    int _count = 0;
-                    for (int i = 0; i < horizon-timezone; i++)
-                    {
-                        shifted_indices[_count+timezone] = i;
-                        _count++;
-                    }
-
-                    _count = 0;
-                    for (int i = horizon-timezone; i <horizon; i++)
-                    {
-                        shifted_indices[_count] = i;
-                        _count++;
-                    }
-                }
-
-                for (int i = 0; i < horizon; i++)
-                    copy_array.Add(sunvectors_list[i]);
-                for (int i = 0; i < horizon; i++)
-                    sunvectors_list[i] = copy_array[shifted_indices[i]];
-            }
+            SunVector.ShiftSunVectorsByTimezone(ref sunvectors_list, timezone);
 
             int count = 0;
             if (draw_solarvec)

--- a/GHSolar/GHSolarMeshHour.cs
+++ b/GHSolar/GHSolarMeshHour.cs
@@ -107,6 +107,8 @@ namespace GHSolar
 
             pManager.AddBooleanParameter("MT", "MT", "Multi threading. Default is (false).", GH_ParamAccess.item);
             pManager[27].Optional = true;
+
+            pManager.AddIntegerParameter("timezone", "timezone", "timezone", GH_ParamAccess.item, 0);
         }
 
         protected override void RegisterOutputParams(GH_Component.GH_OutputParamManager pManager)
@@ -184,6 +186,9 @@ namespace GHSolar
             bool mt = false;
             if (!DA.GetData(27, ref mt)) { mt = false; }
 
+            int timezone = 0;
+            DA.GetData(28, ref timezone);
+
             /////////////////////////////////////////////////////////////////////
             //___________________________________________________________________
             #endregion
@@ -195,8 +200,8 @@ namespace GHSolar
             //______________________________________________________________________________________________
             ////////////////////////////////        S I M U L A T E      ///////////////////////////////////
             CCalculateSolarMesh calc = new CCalculateSolarMesh(
-                mshobj, objObst, treeObst, latitude, longitude, DNI, DHI, SNOW, groundalbedo, snow_threshold, tilt_threshold,
-                year, null, mt, solarAzimuth, solarAltitude);
+                mshobj, objObst, treeObst, latitude, longitude, DNI, DHI, SNOW, groundalbedo, snow_threshold,
+                tilt_threshold, year, null, mt, solarAzimuth, solarAltitude, timezone);
             calc.RunHourSimulationMT(month, day, hour, MainSkyRes, SpecBounces, DiffIReflSkyRes, DiffIReflSkyRes2nd);
             Line ln = calc.getSolarVec();
             CResults results = calc.getResults();

--- a/GHSolar/GHSolarMeshYear.cs
+++ b/GHSolar/GHSolarMeshYear.cs
@@ -122,6 +122,8 @@ namespace GHSolar
 
             pManager.AddBooleanParameter("MT", "MT", "Multi threading. Default is (false).", GH_ParamAccess.item);
             pManager[29].Optional = true;
+
+            pManager.AddIntegerParameter("timezone", "timezone", "timezone", GH_ParamAccess.item, 0);
         }
 
 
@@ -197,6 +199,10 @@ namespace GHSolar
 
             bool mt = false;
             if (!DA.GetData(29, ref mt)) { mt = false; }
+
+            int timezone = 0;
+            DA.GetData(30, ref timezone);
+
             ////////////////////////////////////////////////////////////////////////////////////////////////
             //______________________________________________________________________________________________
 
@@ -204,8 +210,8 @@ namespace GHSolar
             //______________________________________________________________________________________________
             ////////////////////////////////        S I M U L A T E      ///////////////////////////////////
             CCalculateSolarMesh calc = new CCalculateSolarMesh(
-                mshobj, objObst, treeObst, latitude, longitude, DNI, DHI, SNOW, groundalbedo, snow_threshold, tilt_threshold,
-                year, null, mt, solarAzimuth, solarAltitude);
+                mshobj, objObst, treeObst, latitude, longitude, DNI, DHI, SNOW, groundalbedo, snow_threshold,
+                tilt_threshold, year, null, mt, solarAzimuth, solarAltitude, timezone);
             calc.RunAnnualSimulation_MT(
                 mshobj.tolerance, MainSkyRes, MainInterpMode, SpecBounces, SpecInterpMode, DiffIReflSkyRes, DiffIReflSkyRes2nd, DiffIReflMode);
 

--- a/GHSolar/cSolarMesh.cs
+++ b/GHSolar/cSolarMesh.cs
@@ -56,7 +56,8 @@ namespace GHSolar
             double _latitude, double _longitude, List<double> _DNI, List<double> _DHI,
             List<double> _SNOW, List<double> _groundalbedo, double _snow_threshold, double _tilt_threshold,
             int _year, CResultsInterreflections _ResultsIreflIn,
-            bool _mt, List<double> solarAzimuth, List<double> solarAltitude)
+            bool _mt, List<double> solarAzimuth, List<double> solarAltitude,
+            int timezone = 0)
         {
             mshobj = _mshobj;
             objObst = _objObst;
@@ -94,6 +95,7 @@ namespace GHSolar
             else
             {
                 SunVector.Create8760SunVectors(out sunvectors_list, longitude, latitude, year);
+                SunVector.ShiftSunVectorsByTimezone(ref sunvectors_list, timezone);
             }
             sunvectors = sunvectors_list.ToArray();
 

--- a/SolarModel/SunVector.cs
+++ b/SolarModel/SunVector.cs
@@ -314,5 +314,60 @@ namespace SolarModel
                 }
             }
         }
+
+
+        /// <summary>
+        /// needs to be done if weather file with local timezone stamps is used
+        /// </summary>
+        /// <param name="sunVectors"></param>
+        /// <param name="timezone"></param>
+        public static void ShiftSunVectorsByTimezone(ref List<SunVector> sunVectors, int timezone)
+        {
+            //shifting list of sunvectors according to timezone, so it matches weather file data
+            if (timezone != 0)
+            {
+                int horizon = sunVectors.Count;
+                List<SunVector> copyList = new List<SunVector>();
+                int[] shiftedIndices = new int[horizon];
+                for (int i = 0; i < horizon; i++)
+                    shiftedIndices[i] = i;
+                if (timezone < 0)
+                {
+                    int _count = 0;
+                    for (int i = Math.Abs(timezone); i < horizon; i++)
+                    {
+                        shiftedIndices[_count] = i;
+                        _count++;
+                    }
+
+                    for (int i = 0; i < Math.Abs(timezone); i++)
+                    {
+                        shiftedIndices[_count] = i;
+                        _count++;
+                    }
+                }
+                else
+                {
+                    int _count = 0;
+                    for (int i = 0; i < horizon - timezone; i++)
+                    {
+                        shiftedIndices[_count + timezone] = i;
+                        _count++;
+                    }
+
+                    _count = 0;
+                    for (int i = horizon - timezone; i < horizon; i++)
+                    {
+                        shiftedIndices[_count] = i;
+                        _count++;
+                    }
+                }
+
+                for (int i = 0; i < horizon; i++)
+                    copyList.Add(sunVectors[i]);
+                for (int i = 0; i < horizon; i++)
+                    sunVectors[i] = copyList[shiftedIndices[i]];
+            }
+        }
     }
 }


### PR DESCRIPTION
when working with weather files, we need to shift the SunVectors (computed in universal time by Blanco-Muriel) by the respective timezone, such that it matches the local time stamps of the weather file