### PR TITLE
39 irradiance bug

### DIFF
--- a/GHSolar/GHSolarMeshYear.cs
+++ b/GHSolar/GHSolarMeshYear.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using Grasshopper.Kernel;
 using Rhino.Geometry;
-
+using System.Reflection;
 
 /*
  * GHSolarMeshYear.cs
@@ -135,6 +135,10 @@ namespace GHSolar
 
         protected override void SolveInstance(IGH_DataAccess DA)
         {
+            //read InformationalVersion attribute from AssemblyInfo.cs to display as message under the component
+            Message = CMisc.GetInformationalVersionAttribute();
+
+
             //______________________________________________________________________________________________
             ////////////////////////////////        I N P U T S          ///////////////////////////////////
             Mesh msh = new Mesh();

--- a/GHSolar/Properties/AssemblyInfo.cs
+++ b/GHSolar/Properties/AssemblyInfo.cs
@@ -36,3 +36,4 @@ using Rhino.PlugIns;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.2")]

--- a/GHSolar/cMisc.cs
+++ b/GHSolar/cMisc.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Drawing;
 using Rhino.Geometry;
+using System.Reflection;
+using System.Runtime.InteropServices;
 
 /*
  * cMisc.cs
@@ -198,6 +200,18 @@ namespace GHSolar
         public static Point3d OffsetPt(Point3d pt, Vector3d vec, double offset)
         {
             return Point3d.Add(pt, Vector3d.Multiply(Vector3d.Divide(vec, vec.Length), offset));
+        }
+
+
+
+        //read InformationalVersion attribute from AssemblyInfo.cs to display as message under the components
+        public static string GetInformationalVersionAttribute()
+        {
+            Assembly asm = Assembly.GetExecutingAssembly();
+            object[] assemblyInformationalVersion = asm.GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false);
+
+            var versionAttribute = assemblyInformationalVersion[0] as AssemblyInformationalVersionAttribute;
+            return versionAttribute.InformationalVersion;
         }
     }
 }

--- a/SolarModel/Irradiation.cs
+++ b/SolarModel/Irradiation.cs
@@ -60,7 +60,7 @@ namespace SolarModel
             //relative optical air mass
             //double m = 1.0 / Math.Cos(rad * θZ);
 
-            Func<double, double> CalculateRelativeAirMassKasten = (zenithAngleDeg) =>
+            Func<double, double> CalculateAirMassKasten = (zenithAngleDeg) =>
             {
                 double zenithAngleRad = Math.PI * zenithAngleDeg / 180.0;
                 double am = 1.0 / (Math.Cos(zenithAngleRad) + 0.50572 * Math.Pow((96.07995 - zenithAngleDeg), -1.6364));
@@ -68,14 +68,14 @@ namespace SolarModel
             };
 
             // https://pvpmc.sandia.gov/PVLIB_Matlab_Help/
-            Func<double, double> CalculateRelativeAirMassKastenYoung = (solarZenithAngle) =>
+            Func<double, double> CalculateAirMassKastenYoung = (solarZenithAngle) =>
             {
                 double am = 1.0 / (Math.Cos(Math.PI / 180.0 * solarZenithAngle) + 0.50572 *
                     Math.Pow(96.07995 - solarZenithAngle, -1.6364));
                 return am;
             };
 
-            double m = CalculateRelativeAirMassKastenYoung(θZ);
+            double m = CalculateAirMassKastenYoung(θZ);
 
             if (m > 40.0) m = 40.0; //because the simple model is too simple. value could become too high with high zenith angles
 

--- a/SolarModel/Properties/AssemblyInfo.cs
+++ b/SolarModel/Properties/AssemblyInfo.cs
@@ -34,3 +34,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.2")]


### PR DESCRIPTION
closes #39 

the problem was in the Perez diffuse irradiation calculation. The sky brightening factor `delta` was not capped to max 1 earlier, but it should be. To use ChatGPTs words:

_The sky brightness factor in the Perez model, also known as the diffuse horizontal irradiance (DHI) ratio, is defined as the ratio of the diffuse horizontal irradiance to the extraterrestrial irradiance. The value of the DHI ratio can vary from 0 to 1, with 0 indicating a completely clear sky with no scattering of sunlight and 1 indicating a completely overcast sky with no direct sunlight reaching the surface.

Therefore, the sky brightness factor or DHI ratio in the Perez model cannot be larger than 1, as it represents the ratio of the scattered and diffuse light to the total amount of sunlight reaching the surface._


Also changed the air mass model to Kasten Young 1989, which is the default model according to https://pvpmc.sandia.gov/PVLIB_Matlab_Help/